### PR TITLE
Updating the Meteor package to use version 1.1.8 of Ace Editor

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@ var fs = Npm.require("fs");
 Package.describe({
   name: 'arch:ace-editor',
   summary: 'Integrating Ace editor with Meteor since 2015',
-  version: '1.1.1',
+  version: '1.1.8',
   git: 'https://github.com/0a-/meteor-ace-editor'
 });
 


### PR DESCRIPTION
Hi,

I was wondering if you could accept this pull request for the moment. I know Meteor has transitioned to using `api.addAssets()` as opposed to `api.addFiles([],'arch',{isAsset:true})` but this can be addressed in another commit... At some point, lol...

Thanks,
David
